### PR TITLE
[Feat] 루트 시작 시 현재 위치 기반 구간별 대중교통 단계별 길찾기 구현

### DIFF
--- a/src/main/java/com/mey/backend/domain/route/controller/RouteController.java
+++ b/src/main/java/com/mey/backend/domain/route/controller/RouteController.java
@@ -45,6 +45,20 @@ public class RouteController {
     }
 
     @Operation(
+            summary = "루트 시작",
+            description = "현재 위치와 루트 ID를 받아 현재 → 1번째, i번째 → i+1번째 구간의 단계별 길찾기 정보를 반환합니다."
+    )
+    @PostMapping("/{route_id}/start")
+    public CommonResponse<StartRouteResponse> startRoute(
+            @PathVariable("route_id") Long routeId,
+            @RequestParam double latitude,
+            @RequestParam double longitude
+    ) {
+        StartRouteResponse response = routeService.startRoute(routeId, latitude, longitude);
+        return CommonResponse.onSuccess(response);
+    }
+
+    @Operation(
             summary = "추천 루트 조회",
             description = "추천 루트들을 조회한 결과를 반환합니다."
     )

--- a/src/main/java/com/mey/backend/domain/route/dto/StartRouteResponse.java
+++ b/src/main/java/com/mey/backend/domain/route/dto/StartRouteResponse.java
@@ -1,0 +1,12 @@
+package com.mey.backend.domain.route.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StartRouteResponse {
+    private List<TransitSegmentDto> segments;
+}


### PR DESCRIPTION
### 구현 내용
- /{route_id}/start API 추가
- 현재 위치와 루트 ID 기반으로 구간별·단계별 대중교통 경로 조회
- 기존에 연동해둔 TMAP 대중교통 API 를 이용해 경로 계산