### PR TITLE
[Feat] 추천 루트 조회를 목데이터 → 실데이터로 전환(테마 선택적, 인기 루트만 반환)

### DIFF
--- a/src/main/java/com/mey/backend/domain/route/controller/RouteController.java
+++ b/src/main/java/com/mey/backend/domain/route/controller/RouteController.java
@@ -61,17 +61,17 @@ public class RouteController {
     @Operation(
             summary = "추천 루트 조회",
             description = "추천 루트들을 조회한 결과를 반환합니다."
-    )
-    @GetMapping("/recommend")
+    )@GetMapping("/recommend")
     public CommonResponse<RouteRecommendListResponseDto> getRecommendedRoutes(
             @RequestParam(required = false) List<Theme> themes,
-            @RequestParam(required = false) String region,
             @RequestParam(defaultValue = "20") int limit,
             @RequestParam(defaultValue = "0") int offset) {
 
-        RouteRecommendListResponseDto response = routeService.getRecommendedRoutes(themes, region, limit, offset);
+        RouteRecommendListResponseDto response = routeService.getRecommendedRoutes(themes, limit, offset);
         return CommonResponse.onSuccess(response);
     }
+
+
 
     @Operation(
             summary = "루트 아이디로 루트 검색",

--- a/src/main/java/com/mey/backend/domain/route/dto/RouteRecommendResponseDto.java
+++ b/src/main/java/com/mey/backend/domain/route/dto/RouteRecommendResponseDto.java
@@ -1,12 +1,11 @@
 package com.mey.backend.domain.route.dto;
 
+import com.mey.backend.domain.route.entity.Theme;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -14,15 +13,18 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RouteRecommendResponseDto {
-    
-    private Long routeId;
-    private String title;
-    private String description;
-    private String theme;
-    private BigDecimal totalDistanceKm;
-    private Integer totalDurationMinutes;
-    private Integer estimatedCost;
-    private String thumbnailUrl;
-    private Integer popularityScore;
-    private List<LocalTime> availableTimes;
+
+    private Long id;              // 루트 ID
+    private String imageUrl;      // 이미지 URL
+
+    private String titleKo;       // 타이틀 (한글)
+    private String titleEn;       // 타이틀 (영문)
+
+    private String regionNameKo;  // 지역명 (한글)
+    private String regionNameEn;  // 지역명 (영문)
+
+    private String descriptionKo; // 설명 (한글)
+    private String descriptionEn; // 설명 (영문)
+
+    private List<Theme> themes;   // 테마 리스트
 }

--- a/src/main/java/com/mey/backend/domain/route/entity/RouteType.java
+++ b/src/main/java/com/mey/backend/domain/route/entity/RouteType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum RouteType {
+    NORMAL("NORMAL"),
     AI("AI"),               // AI가 생성한 루트
     POPULAR("POPULAR");     // MD가 선정한 루트
 

--- a/src/main/java/com/mey/backend/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/mey/backend/domain/route/repository/RouteRepository.java
@@ -1,6 +1,7 @@
 package com.mey.backend.domain.route.repository;
 
 import com.mey.backend.domain.route.entity.Route;
+import com.mey.backend.domain.route.entity.RouteType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +29,17 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     // 인기도순 정렬 (비용 기준으로 대체)
     @Query("SELECT r FROM Route r ORDER BY r.totalCost ASC")
     List<Route> findAllOrderByPopularity();
+
+
+    // POPULAR 전체
+    List<Route> findByRouteType(RouteType routeType);
+
+    // POPULAR + themes 조건
+    @Query(value = """
+    SELECT *
+    FROM routes r
+    WHERE r.route_type = 'POPULAR'
+      AND JSON_OVERLAPS(r.themes, CAST(:themesJson AS JSON))
+    """, nativeQuery = true)
+    List<Route> findPopularByThemes(@Param("themesJson") String themesJson);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,18 +7,16 @@ spring:
 
   sql:
     init:
-      mode: always
-      data-locations: classpath:sql/data-mysql.sql
+      mode: never
 
   jpa:
     hibernate:
       ddl-auto: create-drop
-    defer-datasource-initialization: true
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
-        format-sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
 
 logging:
   level:


### PR DESCRIPTION
- /routes/recommend 엔드포인트가 DB 실데이터를 사용하도록 구현
- themes 파라미터는 선택적:
    - 값이 있으면 RouteType.POPULAR 중 해당 테마 포함 루트만 반환
    - 값이 없으면 RouteType.POPULAR 전체 반환

Closes #35 