### PR TITLE
[Feat] 인기 장소 조회, 장소 이름 검색, 테마별 장소 검색 API — 다국어 응답 및 openingHours·address·imageUrl 필드 추가

### DIFF
--- a/src/main/java/com/mey/backend/domain/place/dto/PlaceResponseDto.java
+++ b/src/main/java/com/mey/backend/domain/place/dto/PlaceResponseDto.java
@@ -14,15 +14,24 @@ public class PlaceResponseDto {
 
     private String nameKo;
     private String nameEn;
+    private String nameJp;
+    private String nameCh;
 
     private String descriptionKo;
     private String descriptionEn;
+    private String descriptionJp;
+    private String descriptionCh;
 
     private Double longitude;
     private Double latitude;
 
     private String imageUrl;
-    private String address;
+
+    private String addressKo;
+    private String addressEn;
+    private String addressJp;
+    private String addressCh;
+
     private String contactInfo;
     private String websiteUrl;
 
@@ -39,12 +48,19 @@ public class PlaceResponseDto {
         this.regionId = place.getRegion() != null ? place.getRegion().getRegionId() : null;
         this.nameKo = place.getNameKo();
         this.nameEn = place.getNameEn();
+        this.nameJp = place.getNameJp();
+        this.nameCh = place.getNameCh();
         this.descriptionKo = place.getDescriptionKo();
         this.descriptionEn = place.getDescriptionEn();
+        this.descriptionJp = place.getDescriptionJp();
+        this.descriptionCh = place.getDescriptionCh();
         this.longitude = place.getLongitude();
         this.latitude = place.getLatitude();
         this.imageUrl = place.getImageUrl();
-        this.address = place.getAddressKo();
+        this.addressKo = place.getAddressKo();
+        this.addressEn = place.getAddressEn();
+        this.addressJp = place.getAddressJp();
+        this.addressCh = place.getAddressCh();
         this.contactInfo = place.getContactInfo();
         this.websiteUrl = place.getWebsiteUrl();
         this.kakaoPlaceId = place.getKakaoPlaceId();

--- a/src/main/java/com/mey/backend/domain/place/dto/PlaceSimpleResponseDto.java
+++ b/src/main/java/com/mey/backend/domain/place/dto/PlaceSimpleResponseDto.java
@@ -3,22 +3,38 @@ package com.mey.backend.domain.place.dto;
 import com.mey.backend.domain.place.entity.Place;
 import lombok.Getter;
 
+import java.util.Map;
+
 @Getter
 public class PlaceSimpleResponseDto {
 
     private Long id;
     private String nameKo;
     private String nameEn;
+    private String nameJp;
+    private String nameCh;
     private Double longitude;
     private Double latitude;
     private Long regionId;
+    private Map<String, String> openingHours;
+    private String addressKo;
+    private String addressEn;
+    private String addressJp;
+    private String addressCh;
 
     public PlaceSimpleResponseDto(Place place) {
         this.id = place.getPlaceId();
         this.nameKo = place.getNameKo();
         this.nameEn = place.getNameEn();
+        this.nameJp = place.getNameJp();
+        this.nameCh = place.getNameCh();
         this.longitude = place.getLongitude();
         this.latitude = place.getLatitude();
         this.regionId = place.getRegion().getRegionId();
+        this.openingHours = place.getOpeningHours();
+        this.addressKo = place.getAddressKo();
+        this.addressEn = place.getAddressEn();
+        this.addressJp = place.getAddressJp();
+        this.addressCh = place.getAddressCh();
     }
 }

--- a/src/main/java/com/mey/backend/domain/place/dto/PlaceThemeResponseDto.java
+++ b/src/main/java/com/mey/backend/domain/place/dto/PlaceThemeResponseDto.java
@@ -5,17 +5,36 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
 public class PlaceThemeResponseDto {
     private Long id;
     private String nameKo;
+    private String nameEn;
+    private String nameJp;
+    private String nameCh;
     private List<String> themes;
+    private String imageUrl;
+    private Map<String, String> openingHours;
+    private String addressKo;
+    private String addressEn;
+    private String addressJp;
+    private String addressCh;
 
     public PlaceThemeResponseDto(Place place) {
         this.id = place.getPlaceId();
         this.nameKo = place.getNameKo();
+        this.nameEn = place.getNameEn();
+        this.nameJp = place.getNameJp();
+        this.nameCh = place.getNameCh();
         this.themes = place.getThemes();
+        this.imageUrl = place.getImageUrl();
+        this.openingHours = place.getOpeningHours();
+        this.addressKo = place.getAddressKo();
+        this.addressEn = place.getAddressEn();
+        this.addressJp = place.getAddressJp();
+        this.addressCh = place.getAddressCh();
     }
 }


### PR DESCRIPTION
### 인기 장소 조회 API (/popular)
- 다국어 필드(nameKo, nameEn, nameJp, nameCh) 포함

### 장소 이름 검색 API (/search)
- 검색 결과에 다국어 필드 반환
- openingHours, address 필드 응답에 추가

### 테마별 장소 검색 API (/theme)
- 응답에 imageUrl, openingHours, address 필드 추가
- 다국어 필드 반환

Close #58 